### PR TITLE
Remove sensitive .env file from repo

### DIFF
--- a/Code/backend/.env
+++ b/Code/backend/.env
@@ -1,4 +1,0 @@
-RECIPES_DB_URI=mongodb+srv://anuraagjajoo:Q95hNDnuUkr44QvZ@cluster0.lb5su.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
-RECIPES_NS=recipe_recommender
-PORT=5000
-GMAIL= ajajoo3@ncsu.edu

--- a/Code/backend/sample.env
+++ b/Code/backend/sample.env
@@ -1,0 +1,4 @@
+RECIPES_DB_URI=[MongoDB Cluster URL]
+RECIPES_NS=recipe_recommender
+PORT=5000
+GMAIL= [unityID]@ncsu.edu


### PR DESCRIPTION
Replaced '.env' with 'sample.env', which only gives the format for the .env file
A local copy of '.env' will need to be created and filled in for all installations.

Resolves issue #8 