### PR TITLE
Fixed bug making meal plan disappear

### DIFF
--- a/Code/backend/dao/recipesDAO.js
+++ b/Code/backend/dao/recipesDAO.js
@@ -342,6 +342,9 @@ export default class RecipesDAO {
   static async addRecipeToMealPlan(userName, recipeID, weekDay) {
     let response;
     try {
+      if(!recipeID) {
+        throw new Error("recipe id not defined")
+      }
       let updateBody = JSON.parse(
         '{ "meal-plan.' + weekDay + '": "' + recipeID + '" }'
       );

--- a/Code/frontend/src/components/AddToPlanModal.js
+++ b/Code/frontend/src/components/AddToPlanModal.js
@@ -73,8 +73,10 @@ const MiniRecipeCard = (props) => {
 const AddToPlanModal = (props) => {
     const [isOpen, setIsOpen] = useState(false)
     const [day, setDay] = useState(props.day)
-    const [recipeToAdd, setRecipeToAdd] = useState({})
+    const [recipeToAdd, setRecipeToAdd] = useState(null)
     const onClose = () => {
+        setRecipeToAdd(null)
+        setDay(props.day)
         setIsOpen(false)
     }
 
@@ -138,7 +140,7 @@ const AddToPlanModal = (props) => {
                             <option value='saturday'>Saturday</option>
                         </Select>
                         <Spacer />
-                        <Button colorScheme="teal" onClick={() => addToMealPlan()}>Add to Meal Plan</Button>
+                        <Button colorScheme="teal" onClick={() => addToMealPlan()} isDisabled={!recipeToAdd || !day}>Add to Meal Plan</Button>
                     </Box>
                     </ModalBody>
                 </ModalContent>


### PR DESCRIPTION
Add a check to ensure that recipeID is specified in the backend before attempting to add a recipe to the meal plan.
Changed the button on the frontend for adding a recipe to the meal plan to be disabled if a recipe or day have not been selected.

Closes issue #24 